### PR TITLE
Remove step to run docker-setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Note: This project is in **alpha** stage, meaning that it is usable, but will be
 3. Run `docker-compose build mcit`. This will build the docker image whose `/vagrant` folder will be in sync with your current folder (course project folder)
 4. Run `docker-compose run mcit bash`. You should now be inside your docker image, with current folder at `/vagrant`.
 5. Run `ls` to make sure that `docker-setup.sh` is here.
-6. Run `./docker-setup.sh`. This might take 20 minutes to finish.
 
 #### All Future Log-ins
 Just open your course projects folder, and run `docker-compose run mcit bash`.


### PR DESCRIPTION
@zhileiz 
Small note: I noticed that the docker documentation on gdocs:
https://docs.google.com/document/d/1A9W1PdZQFWhKyDn-mCjpWZb6D1U-BQ_p/edit
Differs from the README here on github in that the docker documentation on gdocs does not mention you have to run ./docker-setup.sh.  Indeed, I didn't run docker-setup.sh and it seems like everything worked fine for me.  So not sure if that is actually an accurate step needed in the github readme?

If it is, feel free to disregard this change and I'll close out this branch.