### PR TITLE
Fix errors with setup of Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM ubuntu:20.04
 
+# Remove diverted man binary to prevent man-pages being replaced with "minimized" message. See docker/for-linux#639
+RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then \
+        rm -f /usr/bin/man; \
+        dpkg-divert --quiet --remove --rename /usr/bin/man; \
+    fi
+
+RUN sed -i 's,^path-exclude=/usr/share/man/,#path-exclude=/usr/share/man/,' /etc/dpkg/dpkg.cfg.d/excludes
+
 COPY docker-setup.sh .
 RUN chmod +x docker-setup.sh
 RUN ./docker-setup.sh

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -42,3 +42,9 @@ apt-get install -y tmux
 
 apt-get install -y make
 apt-get install -y gcc
+
+# prevent errors about no dialog installed when attempting to use apt inside container
+apt-get install -y dialog
+
+# install manpages
+apt-get install -y man man-db manpages-posix manpages-dev manpages-posix-dev

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 
-# install llvm
+export DEBIAN_FRONTEND=noninteractive
+
+# install prereqs
 apt-get update
+apt-get install -y apt-utils
+apt-get install -y software-properties-common
+apt-get install -y gnupg
+
+# install llvm
 apt-get -y upgrade
 apt-get install -y wget
 
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-wget -O /home/vagrant/.vimrc https://raw.githubusercontent.com/CIS380/gists/master/example_vimrc.txt
+wget -O /root/.vimrc https://raw.githubusercontent.com/CIS380/gists/master/example_vimrc.txt
 
 add-apt-repository ppa:jonathonf/vim
 apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main"
@@ -25,6 +32,8 @@ apt-get install -y lldb-3.8
 
 apt-get install -y valgrind
 
+apt-get install -y git-all
+apt-get install -y curl
 apt-get install -y vim
 # # PlugInstall can be comment out if you are in win10 and vagrant quit during the initilization.
 vim -c PlugInstall -c qa
@@ -33,4 +42,3 @@ apt-get install -y tmux
 
 apt-get install -y make
 apt-get install -y gcc
-apt-get install -y git-all


### PR DESCRIPTION
- Sets DEBIAN_FRONTEND to noninteractive to silence frontend warnings
- Installs apt-utils upfront
- Installs software-properties-common so that add-apt-repository and apt-add-repository are available as commands
- Installs gnupg so that apt-key works properly for llvm
- Install git and curl before calling PlugInstall so that the plugins can install correctly
- Changes target directory of .vimrc from `/home/vagrant/.vimrc` (which doesn't exist, so it fails) to `/root/.vimrc`
- Some minor warnings remain.