### PR TITLE
Make vimrc available to cit595 user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,6 @@ ARG UID=1000
 RUN addgroup --gid $GID cit595
 RUN useradd --system --create-home --shell /bin/bash --groups sudo -p "$(openssl passwd -1 mcit)" --uid $UID --gid $GID cit595
 RUN chown -R cit595:cit595 /vagrant
+RUN cp /root/.vimrc /home/cit595/.vimrc
+RUN chown cit595:cit595 /home/cit595/.vimrc
 USER cit595


### PR DESCRIPTION
Since the sample vimrc was copied to `/root/.vimrc` in a previous commit to make it available to the root user, and a separate commit added cit595 as the default user, this commit copies root's vimrc to cit595's home folder to also make it available to the cit595 user.

On a side note, the vimrc in question could make the first-time experience of using vim slightly confusing for new users, since on first launch of vim they'll be faced with two vertical panes with the cursor positioned inside the left pane that contains a list of updated vim packages. Might want to have some sort of comment in the readme or wiki explaining that one can simply exit the left pane via `:q` to get to the regular vim interface.